### PR TITLE
fix: Change variable name

### DIFF
--- a/consumat-io.graphql
+++ b/consumat-io.graphql
@@ -3,7 +3,7 @@ type Query {
     tv(code: Int, country: String): TV!
     season(code: Int, seasonNumber: Int): Season!
     episode(code: Int, seasonNumber: Int, episodeNumber: Int): Episode!
-    search(str: String): [Result!]
+    search(keyword: String): [Result!]
 }
     
 type Search {


### PR DESCRIPTION
Caused of the type annotations in the backend I had to change the variable name to clarify what is meant.