### PR TITLE
feat: discover endpoint

### DIFF
--- a/consumat-io.graphql
+++ b/consumat-io.graphql
@@ -6,6 +6,7 @@ type Query {
     search(keyword: String, page: Int): MediaPage
     popular(type: String, country: String, page: Int): MediaPage
     byRating(type: String, country: String, tmdbRating: Float, minVotes: Int, releasedFrom: String, page: Int): MediaPage
+    discover(type: String, person: Int, similarTo: Int, page: Int): MediaPage
     list(type: String, watchStatus: String, favorite: Boolean): [Media]
     tvSeasons(code: Int): [Season]
     seasonEpisodes(code: Int, seasonNumber: Int): [Episode]


### PR DESCRIPTION
Default with only type set will find new media based on user ratings/favorites.
Query should always return results with popular as fallback.
To get movies based on user ratings the following query should be enough:
`discover(type: "Movie", person: null, similarTo: null, page: 1)`

To get movies with a specific actor or director simply add the tmdb code (See https://github.com/alphahorizonio/consumat.io-api/pull/16) like that:
`discover(type: "Movie", person: 12345, similarTo: null, page: 1)`

Unfortunately there is currently no way to do the same with TV shows.
You can however query similar items (movies & tv) based on a tmdb id:
`discover(type: "TV", person: null, similarTo: 12365, page: 1)`
